### PR TITLE
Styles dev GroupExpenseBar

### DIFF
--- a/expense-splitter/src/components/GroupExpenseBar.jsx
+++ b/expense-splitter/src/components/GroupExpenseBar.jsx
@@ -2,43 +2,48 @@ const ExpenseBar = ({ expense, budget }) => {
   const expensePercentage = (expense / budget) * 100;
 
   return (
-    <section className="flex flex-col justify-between max-w-lg rounded-lg p-4 border border-black">
-      <div className="flex justify-between">
-        <p>Expense vs Budget</p>
-        <button>monthly ▼</button>
+    <section className="flex flex-col justify-between w-full max-w-lg ml-8 rounded-lg p-6 bg-white shadow-md">
+      <div className="flex justify-between items-center mb-6">
+        <p className="text-lg font-semibold text-secondary">Expense vs budget</p>
+        <button className="text-sm font-medium text-gray-400 hover:text-secondary">Monthly ▼</button>
       </div>
 
-      <article className="w-full border border-blue-600">
+      <div className="flex justify-between items-start">
+      <article className="w-3/4 pr-4">
         {/* progress bar */}
-        <div className="relative h-5 rounded-full bg-gray-300 mb-2 overflow-hidden">
+        <div className="relative h-6 rounded-lg bg-gray-200 mb-2 mt-4 overflow-hidden">
           <p
-            className="bg-purple-600 h-full rounded-l-full transition-all duration-500 ease-out"
+            className="absolute left-0 top-0 bg-primary h-full rounded-sm transition-all duration-500 ease-out"
             style={{ width: `${expensePercentage}%` }}
           ></p>
         </div>
         {/* numbers */}
-        <div className="flex justify-end mb-4 text-gray-800 relative overflow-hidden">
+        <div className="flex justify-between text-sm font-medium text-gray-600 relative">
           <p
-            style={{ left: `calc(${expensePercentage}% - 13px)` }}
+            style={{         left:
+              expensePercentage > 85
+                ? 'calc(70% - 13px)' // Stop at 85% to avoid overlapping with budget
+                : `calc(${expensePercentage}% - 13px)`, }}
             className="absolute transition-all duration-500 ease-out"
           >
             {expense} $
           </p>
-          <p>{budget} $</p>
+          <p className="ml-auto">{budget} $</p>
         </div>
       </article>
 
-      {/* small card */}
-      <article className="flex flex-col items-start border border-black">
-        <div className="flex items-center">
-          <span className="w-3 h-3 rounded-full bg-purple-600 mr-2"></span>
-          <span>Expense</span>
-        </div>
-        <div className="flex items-center">
-          <span className="w-3 h-3 rounded-full bg-gray-300 mr-2"></span>
-          <span>Budget</span>
-        </div>
-      </article>
+        {/* legend */}
+        <article className="w-1/4 flex flex-col items-start space-y-2 p-4 w-52 h-20 rounded-lg bg-white shadow-xl">
+          <div className="flex items-center">
+            <span className="w-3 h-3 rounded-full bg-primary mr-2"></span>
+            <span className="text-sm font-semibold text-gray-600">Expense</span>
+          </div>
+          <div className="flex items-center">
+            <span className="w-3 h-3 rounded-full bg-gray-300 mr-2"></span>
+            <span className="text-sm font-semibold text-gray-600">Remaining budget</span>
+          </div>
+        </article>
+      </div>
     </section>
   );
 };

--- a/expense-splitter/src/components/GroupExpenseTable.jsx
+++ b/expense-splitter/src/components/GroupExpenseTable.jsx
@@ -112,9 +112,9 @@ const expenses = [
 
 function GroupExpenseTable() {
   return (
-    <div className="overflow-x-auto">
-      <table className="table-auto text-left ">
-        <thead className="border border-gray uppercase bg-orange-100">
+    <div className="overflow-x-auto rounded-lg">
+      <table className="table-auto text-left">
+        <thead className="border border-gray uppercase bg-orange-100 text-sm text-gray-400">
           <tr>
             <th scope="col" className="px-6 py-3">
               Expense
@@ -159,15 +159,15 @@ function GroupExpenseTable() {
                 index % 2 === 0 ? "bg-white " : "bg-gray-50"
               }`}
             >
-              <td className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">
+              <td className="px-6 py-4 font-semibold text-gray-900  whitespace-nowrap">
                 {expense.expense}
               </td>
-              <td className="px-6 py-4">{expense.description}</td>
-              <td className="px-6 py-4">{expense.category}</td>
-              <td className="px-6 py-4">{expense.date}</td>
-              <td className="px-6 py-4">{expense.totalAmount}</td>
+              <td className="px-6 py-4 font-semibold">{expense.description}</td>
+              <td className="px-6 py-4 font-semibold">{expense.category}</td>
+              <td className="px-6 py-4 font-semibold">{expense.date}</td>
+              <td className="px-6 py-4 font-semibold">{expense.totalAmount}</td>
 
-              <td className="px-6 py-4">
+              <td className="px-6 py-4 font-semibold">
                 {expense.participants.map((participant, pindex) => (
                   <div key={pindex} className="flex flex-col">
                     <span>{participant.name}</span>
@@ -175,7 +175,7 @@ function GroupExpenseTable() {
                 ))}
               </td>
 
-              <td className="px-6 py-4">
+              <td className="px-6 py-4 font-semibold">
                 {expense.participants.map((participant, pindex) => (
                   <div key={pindex} className="flex flex-col">
                     <span>{participant.contribution}</span>
@@ -183,7 +183,7 @@ function GroupExpenseTable() {
                 ))}
               </td>
 
-              <td className="px-6 py-4">
+              <td className="px-6 py-4 font-semibold">
                 {expense.participants.map((participant, pindex) => (
                   <div key={pindex} className="flex flex-col">
                     <span>{participant.split}</span>
@@ -191,7 +191,7 @@ function GroupExpenseTable() {
                 ))}
               </td>
 
-              <td className="px-6 py-4">
+              <td className="px-6 py-4 font-semibold">
                 {expense.participants.map((participant, pindex) => (
                   <div key={pindex} className="flex flex-col">
                     <span>{participant.paid}</span>
@@ -199,7 +199,7 @@ function GroupExpenseTable() {
                 ))}
               </td>
 
-              <td className="px-6 py-4">
+              <td className="px-6 py-4 font-semibold">
                 {expense.participants.map((participant, pindex) => (
                   <div key={pindex} className="flex flex-col">
                     <span>{participant.due}</span>
@@ -208,7 +208,7 @@ function GroupExpenseTable() {
               </td>
 
               <td className="px-6 py-4">
-                <button className="text-blue-600 hover:text-blue-900">
+                <button className="text-blue-600 hover:text-primary">
                   View Receipt
                 </button>
               </td>

--- a/expense-splitter/src/components/GroupMembers.jsx
+++ b/expense-splitter/src/components/GroupMembers.jsx
@@ -19,9 +19,9 @@ function GroupMembers() {
   return (
     <div className="bg-white p-4 rounded-lg shadow max-w-lg ml-8">
       <div className="flex justify-between items-center mb-4 ml-4">
-        <p className="text-lg font-semibold text-indigo">Members</p>
+        <p className="text-lg font-semibold text-secondary">Members</p>
         <button className="px-3 py-1 rounded-lg text-sm font-semibold
-        bg-blizzard-blue text-primary hover:bg-indigo hover:text-blizzard-blue transition-colors duration-300">View all</button>
+        bg-blizzard-blue text-primary hover:bg-secondary hover:text-blizzard-blue transition-colors duration-300">View all</button>
       </div>
 
       <div className="flex p-2 space-x-4">
@@ -32,7 +32,7 @@ function GroupMembers() {
 
         <button className="flex-col flex items-center ">
           <MdGroups className="rounded-full w-14 h-14 bg-blizzard-blue p-3 text-primary" />
-          <p className="font-medium text-indigo">Add</p>
+          <p className="font-medium text-secondary">Add</p>
         </button>
       </div>
     </div>

--- a/expense-splitter/src/components/GroupName.jsx
+++ b/expense-splitter/src/components/GroupName.jsx
@@ -2,7 +2,7 @@ function GroupName() {
   return (
     <div className="flex items-center space-x-10 p-8">
       <img className="w-20 h-20 rounded-full object-cover "  src="https://freedomdestinations.co.uk/wp-content/uploads/Diamond-Head-Crater-Honolulu.jpg" alt="group-logo" />
-      <h1 className="text-2xl font-semibold text-indigo">Name of group</h1>
+      <h1 className="text-2xl font-semibold text-secondary">Name of group</h1>
     </div>
   );
 }

--- a/expense-splitter/src/components/GroupSmallExpenseCard.jsx
+++ b/expense-splitter/src/components/GroupSmallExpenseCard.jsx
@@ -9,7 +9,7 @@ function GroupSmallExpenseCard() {
 
       <span>
         <p className="text-sm font-medium text-gray-400">Total budget</p>
-        <p className="font-semibold text-2xl text-indigo">1000 $</p>
+        <p className="font-semibold text-2xl text-secondary">1000 $</p>
       </span>
     </div>
   );

--- a/expense-splitter/src/components/Header.jsx
+++ b/expense-splitter/src/components/Header.jsx
@@ -9,14 +9,14 @@ function Header() {
       </div>
       <div className="flex items-center space-x-5">
         <div className="hidden md:flex">
-          <input className="bg-indigo-100/30 px-4 py-2 rounded-lg focus:outline-0 focus:ring-2 focus:ring-indigo-600" type="text" placeholder="Search" />
+          <input className="bg-secondary-100/30 px-4 py-2 rounded-lg focus:outline-0 focus:ring-2 focus:ring-secondary-600" type="text" placeholder="Search" />
         </div>
         <div className="flex items-center space-x-5">
           <button className="relative text-2xl text-gray-600">
             {/* <GoBell size={28} /> */}
-            <span className="absolute top-0 right-0 -mt-1 -mr-1 flex justify-center items-center bg-indigo-600 text-white font-semibold text-[10px] w-5 h-5 rounded-full border-1 border-white">9</span>
+            <span className="absolute top-0 right-0 -mt-1 -mr-1 flex justify-center items-center bg-secondary-600 text-white font-semibold text-[10px] w-5 h-5 rounded-full border-1 border-white">9</span>
           </button>
-          <img className="w-8 g-8 rounded-full border-2 border-indigo-400" src='https://www.shutterstock.com/image-photo/woman-ok-hand-sign-260nw-459717091.jpg' alt="" />
+          <img className="w-8 g-8 rounded-full border-2 border-secondary-400" src='https://www.shutterstock.com/image-photo/woman-ok-hand-sign-260nw-459717091.jpg' alt="" />
         </div>
       </div>
     </div>

--- a/expense-splitter/src/components/Layout.jsx
+++ b/expense-splitter/src/components/Layout.jsx
@@ -6,7 +6,7 @@ import Sidebar from "./Sidebar";
 
 function Layout() {
   return (
-    <div className="flex">
+    <div className="flex  bg-blizzard-blue">
 
       <Sidebar />
       {/* <Members /> */}

--- a/expense-splitter/src/components/Sidebar.jsx
+++ b/expense-splitter/src/components/Sidebar.jsx
@@ -34,7 +34,7 @@ function Sidebar() {
             key={index}
             to={link.path}
             className={({ isActive }) =>
-              `flex items-center px-4 py-5 space-x-5 hover:bg-secondary ${
+              `flex items-center px-4 py-5 space-x-5  ${
                 isActive ? "text-primary font-bold text-xl" : "text-gray-500 text-sm"
               }`
             }

--- a/expense-splitter/src/components/Sidebar.jsx
+++ b/expense-splitter/src/components/Sidebar.jsx
@@ -34,7 +34,7 @@ function Sidebar() {
             key={index}
             to={link.path}
             className={({ isActive }) =>
-              `flex items-center px-4 py-5 space-x-5 hover:bg-indigo-100 ${
+              `flex items-center px-4 py-5 space-x-5 hover:bg-secondary ${
                 isActive ? "text-primary font-bold text-xl" : "text-gray-500 text-sm"
               }`
             }
@@ -49,7 +49,7 @@ function Sidebar() {
 
       <div className="w-full absolute bottom-5 left-0 px-4 py-2 cursor-pointer text-center">
         <p className="w-full flex items-center justify-center space-x-2 text-sm text-white py-2 px-4
-        bg-primary rounded-xl hover:bg-indigo hover:text-blizzard-blue transition duration-300 ease-in-out">
+        bg-primary rounded-xl hover:bg-secondary hover:text-blizzard-blue transition duration-300 ease-in-out">
           <span>?</span>
           <span className="hidden md:flex">Need help</span>
         </p>

--- a/expense-splitter/src/pages/Groups.jsx
+++ b/expense-splitter/src/pages/Groups.jsx
@@ -4,7 +4,7 @@ import GroupSmallExpenseCard from "../components/GroupSmallExpenseCard";
 
 function Groups() {
   return <div className="p-6 space-y-6 bg-blizzard-blue min-h-screen">
-    
+
     <GroupName/>
     <GroupSmallExpenseCard/>
     <GroupMembers />

--- a/expense-splitter/src/pages/Groups.jsx
+++ b/expense-splitter/src/pages/Groups.jsx
@@ -3,8 +3,16 @@ import GroupName from "../components/GroupName";
 import GroupSmallExpenseCard from "../components/GroupSmallExpenseCard";
 
 function Groups() {
+  return (
+    <div className="flex flex-col gap-8 m-6">
+      <GroupName />
+      <GroupSmallExpenseCard />
+      <ExpenseBar expense={300} budget={1000} />
+      <GroupMembers />
+      <GroupExpenseTable />
+    </div>
+  );
 
-  
 }
 
 export default Groups;

--- a/expense-splitter/src/pages/Groups.jsx
+++ b/expense-splitter/src/pages/Groups.jsx
@@ -3,13 +3,8 @@ import GroupName from "../components/GroupName";
 import GroupSmallExpenseCard from "../components/GroupSmallExpenseCard";
 
 function Groups() {
-  return <div className="p-6 space-y-6 bg-blizzard-blue min-h-screen">
 
-    <GroupName/>
-    <GroupSmallExpenseCard/>
-    <GroupMembers />
-
-  </div>;
+  
 }
 
 export default Groups;

--- a/expense-splitter/tailwind.config.js
+++ b/expense-splitter/tailwind.config.js
@@ -7,9 +7,9 @@ export default {
   theme: {
     extend: {
       colors:{
-        'indigo': '#2B3674',
         'blizzard-blue': '#eefafc',
         'primary':'#1D4ED8',
+        'secondary': '#2B3674',
       }
     },
   },


### PR DESCRIPTION
Hi

This PR addresses the following changes. 
feat(styles): update theme colors and fix progress bar layout

- General styling improvements and consistency across components
- Set indigo as the secondary color in the Tailwind config
- Refactor progress bar to prevent text overlap when expense nears budget
- Adjusted positioning and layout for expense and budget figures
