### PR TITLE
Lot of added logic, read desc for all changes

### DIFF
--- a/expense-splitter/TODO.md
+++ b/expense-splitter/TODO.md
@@ -3,4 +3,5 @@ some reminder for myself (Predrag)
 - try to extract modal logic into a custom hook
 - simplify GroupMembers.jsx by making members automatically wrap inside container so that you can remove "view all" btn
 - replace icons in Total budget/Total expense/Remaining budget cards to be empty not filled, and replace the bugged shopping cart icon with something else
-- add an id to each member so that if they have the same, when you delete one, it will not happen that both get deleted
+- see with Fari to make array of colors that look nice and are the same theme, like sand colors or something. this is for the chart colors on groups page
+- inside GroupMembers.jsx make it so that member cards will wrap automatically and the container expands downwards automatically. for some reason, this is not the case right now by default. member cards should not overflow outside the container

--- a/expense-splitter/TODO.md
+++ b/expense-splitter/TODO.md
@@ -1,0 +1,6 @@
+some reminder for myself (Predrag)
+
+- try to extract modal logic into a custom hook
+- simplify GroupMembers.jsx by making members automatically wrap inside container so that you can remove "view all" btn
+- replace icons in Total budget/Total expense/Remaining budget cards to be empty not filled, and replace the bugged shopping cart icon with something else
+- add an id to each member so that if they have the same, when you delete one, it will not happen that both get deleted

--- a/expense-splitter/src/App.jsx
+++ b/expense-splitter/src/App.jsx
@@ -14,6 +14,7 @@ function App() {
           <Route path="groups" element={<Groups />} />
           <Route path="groups/:groupId" element={<Groups/>} />
           <Route path="friends" element={<Friends />} />
+          <Route path="friends/:friendName" element={<Friends />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/expense-splitter/src/components/Friends/FriendName.jsx
+++ b/expense-splitter/src/components/Friends/FriendName.jsx
@@ -1,8 +1,8 @@
-function FriendName() {
+function FriendName({friendName}) {
     return (
       <section className="flex items-center space-x-10 ">
         <img className="w-69 h-69 ml-10 rounded-full object-cover "  src="https://img.freepik.com/free-photo/portrait-young-businesswoman-holding-eyeglasses-hand-against-gray-backdrop_23-2148029483.jpg?size=338&ext=jpg&ga=GA1.1.2008272138.1726790400&semt=ais_hybrid" alt="friend" />
-        <h1 className="text-header font-bold text-secondary">Name of Friend</h1>
+        <h1 className="text-header font-bold text-secondary">{friendName}</h1>
       </section>
     );
   }

--- a/expense-splitter/src/components/Groups/GroupChart.jsx
+++ b/expense-splitter/src/components/Groups/GroupChart.jsx
@@ -1,13 +1,10 @@
 import { PieChart, Pie, Cell } from "recharts";
+import { useSelector } from "react-redux";
 
-const data = [
-  { name: "Fari", value: 50 },
-  { name: "Luigi", value: 25 },
-  { name: "Mina", value: 25 },
-];
+// chart
+const COLORS = ["#0B7A75", "#843B62", "#F67E7D", "#00A1E4", "#F5B700", "#00A1E4", "#A8C686", "#7067CF", "#E27396", "#DC0073","#89FC00"];
 
-const COLORS = ["#F4A79D", "#4318FF", "#F68D2B"];
-
+// props of numbers inside chart position and radius related 
 const renderCustomizedLabel = ({
   cx,
   cy,
@@ -21,6 +18,7 @@ const renderCustomizedLabel = ({
   const y = cy + radius * Math.sin(-midAngle * (Math.PI / 180));
 
   return (
+    // props of numbers inside chart styling related
     <text
       x={x}
       y={y}
@@ -34,12 +32,29 @@ const renderCustomizedLabel = ({
   );
 };
 
-function GroupChart() {
+function GroupChart({ groupId }) {
+  const groupIdInt = parseInt(groupId);
+
+  const group = useSelector((state) =>
+    state.groups.groups.find((group) => group.id === groupIdInt)
+  );
+
+  if (!group) {
+    return <p>No group found</p>;
+  }
+
+  const data = group.members.map((member) => ({
+    name: member.name,
+    value: member.contribution || 1,
+  }));
+
   return (
     <section className="flex flex-col items-center justify-center w-custom-wide-chart h-custom-height-chart bg-white p-6 ml-8 rounded-lg shadow">
       <div className="w-full flex justify-between">
         <p className="text-lg font-bold text-secondary ml-8">Budget Split</p>
-        <button className="text-body font-medium text-primary bg-blizzard-blue w-30 h-8 mr-8 py-1 px-4 rounded-lg">Members ▼</button>
+        <button className="text-body font-medium text-primary bg-blizzard-blue w-30 h-8 mr-8 py-1 px-4 rounded-lg">
+          Members ▼
+        </button>
       </div>
 
       <PieChart width={171} height={171}>
@@ -47,7 +62,7 @@ function GroupChart() {
           data={data}
           cx={85.5}
           cy={81.9}
-          innerRadius={28.5}
+          innerRadius={20.5}
           outerRadius={57}
           fill="#8884d8"
           paddingAngle={1}

--- a/expense-splitter/src/components/Groups/GroupMembers.jsx
+++ b/expense-splitter/src/components/Groups/GroupMembers.jsx
@@ -1,33 +1,44 @@
 import { MdGroups } from "react-icons/md";
 import GroupsEachMember from "./GroupsEachMember";
+import { useParams } from "react-router-dom";
+import { useSelector } from "react-redux";
 
 // for icons, go to this page https://react-icons.github.io/react-icons/ the search for the icon you need. package is already installed, you just need to import the icon, just like the one above, on line 1. on the webpage, when you click on the icon and open it, you will see the code you need to copy paste to import it. to use the icon, you just put it in JSX like its a normal component. follow the <MdGroups/> example below
 
-const members = [
-  {
-    name: "Tom",
-    img: "https://img.freepik.com/free-photo/young-bearded-man-with-striped-shirt_273609-5677.jpg",
-  },
-  {
-    name: "Mitchel",
-    img: "https://img.freepik.com/free-photo/young-bearded-man-with-striped-shirt_273609-5677.jpg",
-  },
 
-];
 
 function GroupMembers() {
+  const { groupId } = useParams();
+  const group = useSelector((state) =>
+    state.groups.groups.find((group) => group.id === parseInt(groupId))
+  );
+
+  if (!group) {
+    return <div>Group not found.</div>;
+  }
+
   return (
-    <section className="bg-white p-8 pt-6 ml-8 rounded-lg shadow w-custom-width h-48">
+    <section className="bg-white p-6 ml-8 rounded-lg shadow w-custom-width ">
       <div className="flex justify-between items-center mb-4 ml-4">
         <p className="text-lg font-bold text-secondary">Members</p>
-        <button className="w-20 h-8 rounded-lg text-body font-medium
-        bg-blizzard-blue text-primary  duration-300">View all</button>
+        <button
+          className="w-20 h-8 rounded-lg text-body font-medium
+        bg-blizzard-blue text-primary  duration-300"
+        >
+          View all
+        </button>
       </div>
 
       <div className="flex p-2 space-x-4">
         {/* map method */}
-        {members.map((member, index) => (
-          <GroupsEachMember key={index} member={member} index={index} />
+        {group.members.map((member, index) => (
+          <GroupsEachMember
+            key={index}
+            member={{
+              name: member,
+              img: "https://img.freepik.com/free-photo/young-bearded-man-with-striped-shirt_273609-5677.jpg",
+            }}
+          />
         ))}
 
         <button className="flex-col flex items-center ">

--- a/expense-splitter/src/components/Groups/GroupMembers.jsx
+++ b/expense-splitter/src/components/Groups/GroupMembers.jsx
@@ -31,13 +31,13 @@ function GroupMembers() {
     return <div>Group not found.</div>;
   }
 
-  const handleRemoveMember = (memberName) => {
+  const handleRemoveMember = (memberId, memberName) => {
     const confirmed = window.confirm(
       `Are you sure you want to remove ${memberName}?`
     );
 
     if (confirmed) {
-      dispatch(removeMember({ groupId: parseInt(groupId), memberName }));
+      dispatch(removeMember({ groupId: parseInt(groupId), memberId }));
     }
   };
 
@@ -51,11 +51,14 @@ function GroupMembers() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    // Dispatch action to add new member to the group
+
     dispatch(
       addMember({
         groupId: parseInt(groupId),
-        newMember: newMember.name, // Add the name of the new member
+        member: {
+          name: newMember.name,
+          number: newMember.number,
+        },
       })
     );
     setNewMember({ name: "", number: "" });
@@ -82,18 +85,21 @@ function GroupMembers() {
 
       <div className="flex p-2 space-x-4">
         {/* map method */}
-        {group.members.map((member, index) => (
+        {group.members.map((member) => (
           <GroupsEachMember
-            key={index}
-            onRemove={() => handleRemoveMember(member)}
+            key={member.id}
+            onRemove={() => handleRemoveMember(member.id, member.name)}
             member={{
-              name: member,
+              name: member.name,
               img: "https://img.freepik.com/free-photo/young-bearded-man-with-striped-shirt_273609-5677.jpg",
             }}
           />
         ))}
 
-        <button onClick={() => setIsModalOpen(true)} className="flex-col flex items-center ">
+        <button
+          onClick={() => setIsModalOpen(true)}
+          className="flex-col flex items-center "
+        >
           <MdGroups className="rounded-full w-14 h-14 bg-blizzard-blue p-3 text-primary" />
           <p className="text-legend font-bold text-secondary">Add</p>
         </button>

--- a/expense-splitter/src/components/Groups/GroupMembers.jsx
+++ b/expense-splitter/src/components/Groups/GroupMembers.jsx
@@ -87,15 +87,22 @@ function GroupMembers() {
       <div className="flex p-2 space-x-4">
         {/* map method */}
         {group.members.map((member) => (
-          <Link key={member.id} to={`/friends/${member.name}`}>
-            <GroupsEachMember
-              onRemove={() => handleRemoveMember(member.id, member.name)}
-              member={{
-                name: member.name,
-                img: "https://img.freepik.com/free-photo/young-bearded-man-with-striped-shirt_273609-5677.jpg",
-              }}
-            />
-          </Link>
+          <div key={member.id} className="flex flex-col items-center">
+            <Link to={`/friends/${member.name}`} className="hover:bg-slate-200">
+              <GroupsEachMember
+                member={{
+                  name: member.name,
+                  img: "https://img.freepik.com/free-photo/young-bearded-man-with-striped-shirt_273609-5677.jpg",
+                }}
+              />
+            </Link>
+            <button
+              onClick={() => handleRemoveMember(member.id, member.name)}
+              className="bg-highlight flex items-center justify-center rounded-full font-extrabold text-lg text-alert hover:bg-red-400 w-6 h-6 pb-1 relative bottom-20 left-5"
+            >
+              -
+            </button>
+          </div>
         ))}
 
         <button

--- a/expense-splitter/src/components/Groups/GroupMembers.jsx
+++ b/expense-splitter/src/components/Groups/GroupMembers.jsx
@@ -2,16 +2,30 @@ import { MdGroups } from "react-icons/md";
 import GroupsEachMember from "./GroupsEachMember";
 import { useParams } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
-import { removeMember } from "../../features/groupsSlice";
+import { addMember, removeMember } from "../../features/groupsSlice";
+import { useState, useEffect } from "react";
 
 function GroupMembers() {
   const { groupId } = useParams();
-
   const dispatch = useDispatch();
 
   const group = useSelector((state) =>
     state.groups.groups.find((group) => group.id === parseInt(groupId))
   );
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newMember, setNewMember] = useState({ name: "", number: "" });
+
+  // Close modal when pressing Escape
+  useEffect(() => {
+    const handleEsc = (event) => {
+      if (event.key === "Escape") {
+        setIsModalOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleEsc);
+    return () => window.removeEventListener("keydown", handleEsc);
+  }, []);
 
   if (!group) {
     return <div>Group not found.</div>;
@@ -27,8 +41,35 @@ function GroupMembers() {
     }
   };
 
+  const handleAddMemberInputChange = (e) => {
+    const { name, value } = e.target;
+    setNewMember({
+      ...newMember,
+      [name]: value,
+    });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // Dispatch action to add new member to the group
+    dispatch(
+      addMember({
+        groupId: parseInt(groupId),
+        newMember: newMember.name, // Add the name of the new member
+      })
+    );
+    setNewMember({ name: "", number: "" });
+    setIsModalOpen(false);
+  };
+
+  const handleModalClickOutside = (event) => {
+    if (event.target.id === "modal-overlay") {
+      setIsModalOpen(false);
+    }
+  };
+
   return (
-    <section className="bg-white p-6 ml-8 rounded-lg shadow w-custom-width ">
+    <section className="bg-white p-6 ml-8 rounded-lg shadow w-custom-width">
       <div className="flex justify-between items-center mb-4 ml-4">
         <p className="text-lg font-bold text-secondary">Members</p>
         <button
@@ -52,11 +93,68 @@ function GroupMembers() {
           />
         ))}
 
-        <button className="flex-col flex items-center ">
+        <button onClick={() => setIsModalOpen(true)} className="flex-col flex items-center ">
           <MdGroups className="rounded-full w-14 h-14 bg-blizzard-blue p-3 text-primary" />
           <p className="text-legend font-bold text-secondary">Add</p>
         </button>
       </div>
+
+      {isModalOpen && (
+        <section
+          id="modal-overlay"
+          className="fixed inset-0 bg-black bg-opacity-20 flex justify-center items-center"
+          onClick={handleModalClickOutside}
+        >
+          <article className="bg-white p-6 rounded-lg w-96">
+            <div className="flex justify-between items-center">
+              <h2 className="text-2xl mb-4 font-bold">Add New Member</h2>
+              <button
+                className="bg-white shadow rounded-full w-8 h-8 text-red-500 mb-4"
+                onClick={() => setIsModalOpen(false)}
+              >
+                x
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <div>
+                <label className="text-body font-semibold">Member Name</label>
+                <input
+                  type="text"
+                  name="name"
+                  value={newMember.name}
+                  onChange={handleAddMemberInputChange}
+                  className="border p-2 w-full"
+                  placeholder="Enter member name"
+                  required
+                  style={{ fontSize: "14px" }}
+                />
+              </div>
+
+              <div>
+                <label className="text-body font-semibold">Member Number</label>
+                <input
+                  type="text"
+                  name="number"
+                  value={newMember.number}
+                  onChange={handleAddMemberInputChange}
+                  className="border p-2 w-full"
+                  placeholder="Enter member number"
+                  required
+                  style={{ fontSize: "14px" }}
+                />
+              </div>
+
+              <button
+                type="submit"
+                className="px-4 py-2 bg-primary text-white rounded-xl"
+              >
+                Add Member
+              </button>
+            </form>
+          </article>
+        </section>
+      )}
     </section>
   );
 }

--- a/expense-splitter/src/components/Groups/GroupMembers.jsx
+++ b/expense-splitter/src/components/Groups/GroupMembers.jsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import { addMember, removeMember } from "../../features/groupsSlice";
 import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 
 function GroupMembers() {
   const { groupId } = useParams();
@@ -86,14 +87,15 @@ function GroupMembers() {
       <div className="flex p-2 space-x-4">
         {/* map method */}
         {group.members.map((member) => (
-          <GroupsEachMember
-            key={member.id}
-            onRemove={() => handleRemoveMember(member.id, member.name)}
-            member={{
-              name: member.name,
-              img: "https://img.freepik.com/free-photo/young-bearded-man-with-striped-shirt_273609-5677.jpg",
-            }}
-          />
+          <Link key={member.id} to={`/friends/${member.name}`}>
+            <GroupsEachMember
+              onRemove={() => handleRemoveMember(member.id, member.name)}
+              member={{
+                name: member.name,
+                img: "https://img.freepik.com/free-photo/young-bearded-man-with-striped-shirt_273609-5677.jpg",
+              }}
+            />
+          </Link>
         ))}
 
         <button

--- a/expense-splitter/src/components/Groups/GroupsEachMember.jsx
+++ b/expense-splitter/src/components/Groups/GroupsEachMember.jsx
@@ -1,15 +1,12 @@
-function GroupsEachMember({ member, index }) {
+function GroupsEachMember({ member }) {
   return (
-    <section
-      key={index}
-      className="relative flex flex-col w-20 items-center text-center"
-    >
+    <section className="relative flex flex-col w-20 items-center text-center">
       <img
         className="object-cover w-14 h-14 rounded-full shadow-lg"
         src={member.img}
         alt={member.name}
       />
-      <p className="text-legend font-bold text-legend">{member.name}</p>
+      <p className="font-bold text-legend">{member.name}</p>
       <button className="bg-highlight flex items-center justify-center rounded-full font-extrabold text-lg text-alert w-6 h-6 pb-1 bottom-20 relative left-7">
         -
       </button>

--- a/expense-splitter/src/components/Groups/GroupsEachMember.jsx
+++ b/expense-splitter/src/components/Groups/GroupsEachMember.jsx
@@ -1,15 +1,12 @@
-function GroupsEachMember({ member, onRemove }) {
+function GroupsEachMember({ member }) {
   return (
-    <section className="relative flex flex-col w-20 items-center text-center">
+    <section className="flex flex-col w-20 items-center text-center">
       <img
         className="object-cover w-14 h-14 rounded-full shadow-lg"
         src={member.img}
         alt={member.name}
       />
       <p className="font-bold text-legend">{member.name}</p>
-      <button onClick={onRemove} className="bg-highlight flex items-center justify-center rounded-full font-extrabold text-lg text-alert w-6 h-6 pb-1 bottom-20 relative left-7">
-        -
-      </button>
     </section>
   );
 }

--- a/expense-splitter/src/components/Home/HomeIndividualGroup.jsx
+++ b/expense-splitter/src/components/Home/HomeIndividualGroup.jsx
@@ -16,7 +16,7 @@ function HomeIndividualGroup({ group }) {
   };
 
   return (
-    <section className="p-4 border bg-white rounded-xl w-72 h-36 ml-8 w-custom-card h-custom-card-height flex flex-col items-center">
+    <section className="p-4 border bg-white rounded-xl ml-8 w-custom-card h-custom-card-height flex flex-col items-center">
       <img className="w-14 h-14 mb-2 rounded-full object-cover flex justify-center"
         src="https://freedomdestinations.co.uk/wp-content/uploads/Diamond-Head-Crater-Honolulu.jpg" alt="group-logo" />
 

--- a/expense-splitter/src/features/groupsSlice.js
+++ b/expense-splitter/src/features/groupsSlice.js
@@ -7,7 +7,7 @@ const initialState = {
       name: "Picnic Holiday",
       totalBudget: 500,
       totalExpense: 300,
-      members: ["Mark", "Tom"],
+      members: ["Mark", "Jason", "Conan"],
     },
     {
       id: 2,
@@ -30,25 +30,9 @@ const groupsSlice = createSlice({
       state.groups = state.groups.filter(
         (group) => group.id !== action.payload
       );
-      // Remove associated friends when group is deleted. uncomenting this piece will make the remove group button NOT WORK 
-      // state.groups.members = state.groups.members.filter(
-      //   (friend) => friend.group !== action.payload
-      // );
-    },
-    addFriendToGroup: (state, action) => {
-      const { groupId, friendName } = action.payload;
-      const group = state.groups.find((group) => group.id === groupId);
-      if (group) {
-        group.members.push(friendName);
-        state.friends.push({
-          id: Date.now(),
-          name: friendName,
-          group: group.name,
-        });
-      }
     },
   },
 });
 
-export const { addGroup, removeGroup, addFriendToGroup } = groupsSlice.actions;
+export const { addGroup, removeGroup, removeMember } = groupsSlice.actions;
 export default groupsSlice.reducer;

--- a/expense-splitter/src/features/groupsSlice.js
+++ b/expense-splitter/src/features/groupsSlice.js
@@ -7,7 +7,11 @@ const initialState = {
       name: "Picnic Holiday",
       totalBudget: 500,
       totalExpense: 300,
-      members: ["Mark", "Jason", "Conan"],
+      members: [
+        { id: 1, name: "Mark", number: "12345" },
+        { id: 2, name: "Jason", number: "67890" },
+        { id: 3, name: "Conan", number: "11223" },
+      ],
     },
     // {
     //   id: 2,
@@ -32,21 +36,25 @@ const groupsSlice = createSlice({
       );
     },
     addMember: (state, action) => {
-      const { groupId, newMember } = action.payload;
+      const { groupId, member } = action.payload;
       const group = state.groups.find((group) => group.id === groupId);
       if (group) {
-        group.members.push(newMember);
+        group.members.push({
+          id: Date.now(), 
+          ...member,    
+        });
       }
     },
     removeMember: (state, action) => {
-      const { groupId, memberName } = action.payload;
+      const { groupId, memberId  } = action.payload;
       const group = state.groups.find((group) => group.id === groupId);
       if (group) {
-        group.members = group.members.filter((member) => member !== memberName);
+        group.members = group.members.filter((member) => member.id !== memberId);
       }
     },
   },
 });
 
-export const { addGroup, removeGroup, addMember, removeMember } = groupsSlice.actions;
+export const { addGroup, removeGroup, addMember, removeMember } =
+  groupsSlice.actions;
 export default groupsSlice.reducer;

--- a/expense-splitter/src/features/groupsSlice.js
+++ b/expense-splitter/src/features/groupsSlice.js
@@ -9,13 +9,13 @@ const initialState = {
       totalExpense: 300,
       members: ["Mark", "Jason", "Conan"],
     },
-    {
-      id: 2,
-      name: "Hiking",
-      totalBudget: 1000,
-      totalExpense: 700,
-      members: ["Jane", "Mary"],
-    },
+    // {
+    //   id: 2,
+    //   name: "Hiking",
+    //   totalBudget: 1000,
+    //   totalExpense: 700,
+    //   members: ["Jane", "Mary"],
+    // },
   ],
 };
 
@@ -31,6 +31,13 @@ const groupsSlice = createSlice({
         (group) => group.id !== action.payload
       );
     },
+    addMember: (state, action) => {
+      const { groupId, newMember } = action.payload;
+      const group = state.groups.find((group) => group.id === groupId);
+      if (group) {
+        group.members.push(newMember);
+      }
+    },
     removeMember: (state, action) => {
       const { groupId, memberName } = action.payload;
       const group = state.groups.find((group) => group.id === groupId);
@@ -41,5 +48,5 @@ const groupsSlice = createSlice({
   },
 });
 
-export const { addGroup, removeGroup, removeMember } = groupsSlice.actions;
+export const { addGroup, removeGroup, addMember, removeMember } = groupsSlice.actions;
 export default groupsSlice.reducer;

--- a/expense-splitter/src/features/groupsSlice.js
+++ b/expense-splitter/src/features/groupsSlice.js
@@ -1,5 +1,15 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+const calculateContributions = (group) => {
+  const memberCount = group.members.length;
+  if (memberCount > 0) {
+    const contribution = group.totalExpense / memberCount;
+    group.members.forEach((member) => {
+      member.contribution = contribution;
+    });
+  }
+};
+
 const initialState = {
   groups: [
     {
@@ -8,18 +18,11 @@ const initialState = {
       totalBudget: 500,
       totalExpense: 300,
       members: [
-        { id: 1, name: "Mark", number: "12345" },
-        { id: 2, name: "Jason", number: "67890" },
-        { id: 3, name: "Conan", number: "11223" },
+        { id: 1, name: "Mark", contribution: 0 },
+        { id: 2, name: "Jason", contribution: 0 },
+        { id: 3, name: "Conan", contribution: 0 },
       ],
     },
-    // {
-    //   id: 2,
-    //   name: "Hiking",
-    //   totalBudget: 1000,
-    //   totalExpense: 700,
-    //   members: ["Jane", "Mary"],
-    // },
   ],
 };
 
@@ -40,16 +43,27 @@ const groupsSlice = createSlice({
       const group = state.groups.find((group) => group.id === groupId);
       if (group) {
         group.members.push({
-          id: Date.now(), 
-          ...member,    
+          id: Date.now(),
+          ...member,
         });
+        calculateContributions(group);
       }
     },
     removeMember: (state, action) => {
-      const { groupId, memberId  } = action.payload;
+      const { groupId, memberId } = action.payload;
       const group = state.groups.find((group) => group.id === groupId);
       if (group) {
-        group.members = group.members.filter((member) => member.id !== memberId);
+        group.members = group.members.filter(
+          (member) => member.id !== memberId
+        );
+      }
+    },
+    updateTotalExpense: (state, action) => {
+      const { groupId, totalExpense } = action.payload;
+      const group = state.groups.find((group) => group.id === groupId);
+      if (group) {
+        group.totalExpense = totalExpense;
+        calculateContributions(group);
       }
     },
   },

--- a/expense-splitter/src/pages/Friends.jsx
+++ b/expense-splitter/src/pages/Friends.jsx
@@ -1,18 +1,20 @@
-import FriendsTable from "../components/Friends/FriendsTable"
-import FriendsMutualGroups from "../components/Friends/FriendsMutualGroups"
-import FriendName from "../components/Friends/FriendName"
-import FriendsChart from "../components/Friends/FriendsChart"
+import FriendsTable from "../components/Friends/FriendsTable";
+import FriendsMutualGroups from "../components/Friends/FriendsMutualGroups";
+import FriendName from "../components/Friends/FriendName";
+import FriendsChart from "../components/Friends/FriendsChart";
+import { useParams } from "react-router-dom";
 
 function Friends() {
-    return (
-        <section className="flex flex-col gap-5 m-6">
-            <FriendName />
-            <FriendsMutualGroups />
-            <FriendsChart />
-            <FriendsTable />
+  const { friendName } = useParams();
 
-        </section>
-    )
+  return (
+    <section className="flex flex-col gap-5 m-6">
+      <FriendName friendName={friendName} />
+      <FriendsMutualGroups />
+      <FriendsChart />
+      <FriendsTable />
+    </section>
+  );
 }
 
-export default Friends
+export default Friends;

--- a/expense-splitter/src/pages/Groups.jsx
+++ b/expense-splitter/src/pages/Groups.jsx
@@ -47,7 +47,7 @@ const totalBudget = group.totalBudget;  // fake values update with actual logic 
       </div>
 
       <ExpenseBar expense={totalExpense} budget={totalBudget} />
-      <GroupChart />
+      <GroupChart groupId={groupId} />
       <GroupMembers members={group.members} />
       <GroupExpenseTable />
     </section>


### PR DESCRIPTION
When the user clicks group details from the main page, and goes to individual group details, in the section "Members", the user is now able to: 
- see the group members dinamically, which means, depending on what group the user selected (right now, only 1 is default and always present) the user will see the names of those group members
- add new members
- remove existing members
- by clicking on member card (image or name), be routed to that specific member details where, for now, only name is dynamically displayed
- see the chart component with chart correctly and dynamically displaying contributions (all members contribute equally for now) and also the names of group members where each has his own color in the chart and legend